### PR TITLE
refactor: Clean up integration test code

### DIFF
--- a/tests/integration/constants.ts
+++ b/tests/integration/constants.ts
@@ -1,0 +1,40 @@
+import { type Address, parseEther, parseUnits } from 'viem'
+
+/** Test constants for integration tests */
+export const TEST_CONSTANTS = {
+  /** Known weETH whale address with substantial balance */
+  WHALE_ADDRESS: '0x566d2176Ecb1d8eA07D182b47B5aC57511337E00' as Address,
+  
+  /** EtherFi L2ModeSyncPool address on Base */
+  ETHERFI_POOL: '0xc38e046dFDAdf15f7F56853674242888301208a5' as Address,
+  
+  /** Test amounts */
+  AMOUNTS: {
+    /** Gas funding amount */
+    GAS_FUNDING: parseEther('10'),
+    /** Test equity amount (1 weETH) */
+    EQUITY: parseUnits('1', 18),
+    /** Max swap cost (5% of equity) */
+    MAX_SWAP_COST_BPS: 500n, // 5%
+    /** Slippage tolerance (1%) */  
+    SLIPPAGE_BPS: 100n, // 1%
+  },
+  
+  /** Tenderly funding amount (100 ETH) */
+  TENDERLY_BALANCE: '0x56bc75e2d630e8000',
+} as const
+
+/** Calculate derived values */
+export function calculateMintParams(equityAmount: bigint) {
+  const maxSwapCost = (equityAmount * TEST_CONSTANTS.AMOUNTS.MAX_SWAP_COST_BPS) / 10000n
+  const amountAfterSwapCost = equityAmount - maxSwapCost
+  
+  return {
+    maxSwapCost,
+    amountAfterSwapCost,
+  }
+}
+
+export function calculateMinShares(expectedShares: bigint, slippageBps = TEST_CONSTANTS.AMOUNTS.SLIPPAGE_BPS) {
+  return (expectedShares * (10000n - slippageBps)) / 10000n
+}

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,0 +1,155 @@
+import { type Address, erc20Abi, maxUint256, encodeAbiParameters, zeroAddress } from 'viem'
+import { leverageManagerAbi } from '../../src/lib/contracts/abis/leverageManager'
+import { leverageRouterAbi } from '../../src/lib/contracts/abis/leverageRouter' 
+import { createSwapContext } from '../../src/features/leverage-tokens/utils/swapContext'
+import { TEST_CONSTANTS, calculateMinShares } from './constants'
+import { testClient, publicClient, walletClient } from './setup'
+
+// Base token addresses (from V1 working version)
+export const BASE_TOKEN_ADDRESSES = {
+  weETH: '0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A' as Address,
+  WETH: '0x4200000000000000000000000000000000000006' as Address,
+  ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' as Address,
+}
+
+// Create weETH-specific swap context (matching V1 working pattern)
+export function createWeETHSwapContext() {
+  return createSwapContext(
+    BASE_TOKEN_ADDRESSES.weETH, // collateral
+    BASE_TOKEN_ADDRESSES.WETH,  // debt asset
+    8453 // Base chain ID
+  )
+}
+
+/** Account setup for whale testing */
+export async function setupWhaleAccount(whaleAddress: Address = TEST_CONSTANTS.WHALE_ADDRESS) {
+  const account = { address: whaleAddress, type: 'json-rpc' } as const
+  
+  // Try Tenderly funding first, fallback to regular funding
+  try {
+    await publicClient.request({
+      method: 'tenderly_setBalance', 
+      params: [[account.address], TEST_CONSTANTS.TENDERLY_BALANCE]
+    })
+  } catch {
+    // Fallback will happen in fund.native
+  }
+
+  // Try account impersonation (Anvil only)
+  try {
+    await testClient.impersonateAccount({ address: account.address })
+  } catch {
+    // Tenderly doesn't support impersonation but has real balances
+  }
+
+  return account
+}
+
+/** Get leverage token metadata */
+export async function getLeverageTokenData(leverageToken: Address, manager: Address) {
+  const [collateralAsset, debtAsset, tokenConfig] = await Promise.all([
+    publicClient.readContract({
+      address: manager,
+      abi: leverageManagerAbi,
+      functionName: 'getLeverageTokenCollateralAsset',
+      args: [leverageToken],
+    }),
+    publicClient.readContract({
+      address: manager, 
+      abi: leverageManagerAbi,
+      functionName: 'getLeverageTokenDebtAsset',
+      args: [leverageToken],
+    }),
+    publicClient.readContract({
+      address: manager,
+      abi: leverageManagerAbi, 
+      functionName: 'getLeverageTokenConfig',
+      args: [leverageToken],
+    })
+  ])
+
+  return {
+    collateralAsset: collateralAsset as Address,
+    debtAsset: debtAsset as Address,
+    tokenConfig,
+  }
+}
+
+/** Approve Router to spend collateral (V1 pattern) */
+export async function approveRouter(
+  collateralAsset: Address,
+  router: Address,
+  account: { address: Address; type: 'json-rpc' }
+) {
+  const { request } = await publicClient.simulateContract({
+    address: collateralAsset,
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [router, maxUint256],
+    account,
+  })
+  
+  const hash = await walletClient.writeContract(request)
+  await publicClient.waitForTransactionReceipt({ hash })
+}
+
+/** Preview mint and calculate parameters */
+export async function previewMint(
+  manager: Address,
+  leverageToken: Address,
+  amountAfterSwapCost: bigint
+) {
+  const preview = await publicClient.readContract({
+    address: manager,
+    abi: leverageManagerAbi,
+    functionName: 'previewMint',
+    args: [leverageToken, amountAfterSwapCost],
+  })
+
+  return {
+    shares: preview.shares,
+    minShares: calculateMinShares(preview.shares),
+    tokenFee: preview.tokenFee,
+    treasuryFee: preview.treasuryFee,
+  }
+}
+
+/** Simulate Router.mint transaction */
+export async function simulateRouterMint(
+  router: Address,
+  leverageToken: Address,
+  amountAfterSwapCost: bigint,
+  minShares: bigint,
+  maxSwapCost: bigint,
+  account: { address: Address; type: 'json-rpc' }
+) {
+  const swapContext = createWeETHSwapContext()
+  
+  await publicClient.simulateContract({
+    address: router,
+    abi: leverageRouterAbi,
+    functionName: 'mint', 
+    args: [leverageToken, amountAfterSwapCost, minShares, maxSwapCost, swapContext],
+    account,
+  })
+}
+
+/** Check token balance */
+export async function getTokenBalance(token: Address, account: Address) {
+  return publicClient.readContract({
+    address: token,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [account],
+  })
+}
+
+/** Check token allowance */
+export async function getTokenAllowance(token: Address, owner: Address, spender: Address) {
+  return publicClient.readContract({
+    address: token,
+    abi: erc20Abi,
+    functionName: 'allowance',
+    args: [owner, spender],
+  })
+}


### PR DESCRIPTION
## Summary

Major cleanup of integration tests to improve maintainability and follow clean code principles.

### New Structure
- **`tests/integration/constants.ts`**: Test constants and calculation helpers  
- **`tests/integration/helpers.ts`**: Reusable test utilities and setup functions
- **Focused, atomic tests** with clear single responsibilities

### Key Improvements
- ✅ **Extracted hardcoded values** to constants (whale address, amounts, addresses)
- ✅ **Created helper functions** for common operations (approval, balance checks, etc.)  
- ✅ **Removed verbose console.log** debugging statements
- ✅ **Split monolithic test** into focused, atomic tests
- ✅ **Clean separation of concerns** (setup, data fetching, assertions)
- ✅ **Proper V1 pattern**: single Router approval (not dual EtherFi approval)

### Test Coverage
- ✅ Preview mint functionality
- ✅ Collateral asset verification (weETH)
- ✅ Router.mint simulation with V1 pattern  
- ✅ Allowance checking

### Before/After
**Before**: 545 lines of messy debugging code with hardcoded values
**After**: 238 lines of clean, maintainable, focused tests

## Test Plan
- [ ] Integration tests pass locally
- [ ] Tests follow clean code principles  
- [ ] No regression in functionality
- [ ] Ready for production use

🤖 Generated with [Claude Code](https://claude.ai/code)