### PR TITLE
ui: show approval status as n/a when no input is set

### DIFF
--- a/src/features/leverage-tokens/components/leverage-token-mint-modal/InputStep.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-mint-modal/InputStep.tsx
@@ -308,7 +308,9 @@ export function InputStep({
           <div className="flex justify-between">
             <span className="text-slate-400">Approval Status</span>
             <span className={needsApproval ? 'text-yellow-400' : 'text-green-400'}>
-              {isAllowanceLoading ? (
+              {!amount || parseFloat(amount || '0') === 0 ? (
+                <span className="text-slate-400">N/A</span>
+              ) : isAllowanceLoading ? (
                 <Skeleton className="inline-block h-3 w-16" />
               ) : needsApproval ? (
                 'Approval Required'

--- a/src/features/leverage-tokens/components/leverage-token-redeem-modal/InputStep.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-redeem-modal/InputStep.tsx
@@ -399,7 +399,9 @@ export function InputStep({
           <div className="flex justify-between">
             <span className="text-slate-400">Approval Status</span>
             <span className={needsApproval ? 'text-yellow-400' : 'text-green-400'}>
-              {isAllowanceLoading ? (
+              {!amount || parseFloat(amount || '0') === 0 ? (
+                <span className="text-slate-400">N/A</span>
+              ) : isAllowanceLoading ? (
                 <Skeleton className="inline-block h-3 w-16" />
               ) : needsApproval ? (
                 'Approval Required'


### PR DESCRIPTION
fixes https://github.com/seamless-protocol/app/issues/168