### PR TITLE
fix: leverage token page uses leverage manager v2

### DIFF
--- a/src/features/leverage-tokens/hooks/useLeverageTokenCollateral.ts
+++ b/src/features/leverage-tokens/hooks/useLeverageTokenCollateral.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import { useChainId, useReadContracts } from 'wagmi'
-import { lendingAdapterAbi, leverageManagerAbi } from '@/lib/contracts'
+import { lendingAdapterAbi, leverageManagerV2Abi } from '@/lib/contracts'
 import { getLeverageManagerAddress, type SupportedChainId } from '@/lib/contracts/addresses'
 import { STALE_TIME } from '../utils/constants'
 
@@ -33,7 +33,7 @@ export function useLeverageTokenCollateral(
     contracts: [
       {
         address: managerAddress,
-        abi: leverageManagerAbi,
+        abi: leverageManagerV2Abi,
         functionName: 'getLeverageTokenConfig',
         args: tokenAddress ? [tokenAddress] : undefined,
         chainId: chainId as SupportedChainId,

--- a/src/features/leverage-tokens/hooks/useLeverageTokenDetailedMetrics.ts
+++ b/src/features/leverage-tokens/hooks/useLeverageTokenDetailedMetrics.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'viem'
 import { useReadContracts } from 'wagmi'
 import { lendingAdapterAbi } from '../../../lib/contracts/abis/lendingAdapter'
-import { leverageManagerAbi } from '../../../lib/contracts/abis/leverageManager'
+import { leverageManagerV2Abi } from '../../../lib/contracts/abis/leverageManagerV2'
 import { rebalanceAdapterAbi } from '../../../lib/contracts/abis/rebalanceAdapter'
 import { getLeverageManagerAddress, type SupportedChainId } from '../../../lib/contracts/addresses'
 import type { LeverageTokenMetrics } from '../components/LeverageTokenDetailedMetrics'
@@ -46,14 +46,14 @@ export function useLeverageTokenDetailedMetrics(tokenAddress?: Address) {
     contracts: [
       {
         address: managerAddress,
-        abi: leverageManagerAbi,
+        abi: leverageManagerV2Abi,
         functionName: 'getLeverageTokenConfig',
         args: tokenAddress ? [tokenAddress] : undefined,
         chainId: chainId as SupportedChainId,
       },
       {
         address: managerAddress,
-        abi: leverageManagerAbi,
+        abi: leverageManagerV2Abi,
         functionName: 'getLeverageTokenState',
         args: tokenAddress ? [tokenAddress] : undefined,
         chainId: chainId as SupportedChainId,

--- a/src/features/leverage-tokens/hooks/useLeverageTokenState.ts
+++ b/src/features/leverage-tokens/hooks/useLeverageTokenState.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import type { Address } from 'viem'
 import { useChainId, useReadContracts } from 'wagmi'
-import { leverageManagerAbi, leverageManagerV2Abi, leverageTokenAbi } from '@/lib/contracts'
+import { leverageManagerV2Abi, leverageTokenAbi } from '@/lib/contracts'
 import { getContractAddresses, type SupportedChainId } from '@/lib/contracts/addresses'
 import { STALE_TIME } from '../utils/constants'
 
@@ -16,18 +16,14 @@ export function useLeverageTokenState(tokenAddress: Address, chainIdOverride?: n
   const walletChainId = useChainId()
   const chainId = chainIdOverride ?? walletChainId
   const contractAddresses = getContractAddresses(chainId)
-  const managerAddress = contractAddresses?.leverageManagerV2 ?? contractAddresses?.leverageManager
-  const isV2Manager = Boolean(
-    contractAddresses?.leverageManagerV2 && managerAddress === contractAddresses?.leverageManagerV2,
-  )
-  const managerAbi = isV2Manager ? leverageManagerV2Abi : leverageManagerAbi
+  const managerAddress = contractAddresses?.leverageManagerV2
 
   const contracts = useMemo(() => {
     if (!managerAddress || !tokenAddress) return []
     return [
       {
         address: managerAddress as Address,
-        abi: managerAbi,
+        abi: leverageManagerV2Abi,
         functionName: 'getLeverageTokenState' as const,
         args: [tokenAddress],
         chainId: chainId as SupportedChainId,
@@ -39,7 +35,7 @@ export function useLeverageTokenState(tokenAddress: Address, chainIdOverride?: n
         chainId: chainId as SupportedChainId,
       },
     ]
-  }, [managerAddress, managerAbi, tokenAddress, chainId])
+  }, [managerAddress, tokenAddress, chainId])
 
   const { data, isLoading, isError, error } = useReadContracts({
     contracts,


### PR DESCRIPTION
## Summary
- ensure leverage token collateral reads use leverageManagerV2
- update detailed metrics to query leverageManagerV2 state/config
- restrict leverage token state hook to leverageManagerV2 to match deployed setup

## Testing
- bun check:fix
