### PR TITLE
fix: remove top rewards tag

### DIFF
--- a/_figma/src/components/pages/ExploreStrategies.tsx
+++ b/_figma/src/components/pages/ExploreStrategies.tsx
@@ -322,9 +322,6 @@ export function ExploreStrategies({ onViewStrategy }: ExploreStrategiesProps) {
             <Zap className="h-5 w-5 text-yellow-400" />
             <span>Featured</span>
           </h2>
-          <Badge variant="outline" className="text-yellow-400 border-yellow-400/30 bg-yellow-400/10">
-            Top Rewards
-          </Badge>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">

--- a/src/features/leverage-tokens/components/FeaturedLeverageToken.tsx
+++ b/src/features/leverage-tokens/components/FeaturedLeverageToken.tsx
@@ -143,9 +143,6 @@ export function FeaturedLeverageTokens({
           <Zap className="h-5 w-5 text-yellow-400" />
           <span>Featured</span>
         </h2>
-        <Badge variant="outline" className="text-yellow-400 border-yellow-400/30 bg-yellow-400/10">
-          Top Rewards
-        </Badge>
       </div>
 
       {/* Cards Grid */}


### PR DESCRIPTION
## Summary
- remove the Top Rewards badge from the featured leverage tokens section
- mirror the same change in the Figma-derived ExploreStrategies reference

## Testing
- bun check:fix

Fixes #197