### PR TITLE
feat: add morpho vaults info card

### DIFF
--- a/_figma/src/components/icons/logos/MorphoLogo.tsx
+++ b/_figma/src/components/icons/logos/MorphoLogo.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React from "react"
+
+interface MorphoLogoProps {
+  className?: string
+  size?: number
+}
+
+export function MorphoLogo({ className = "", size = 48 }: MorphoLogoProps) {
+  const titleId = React.useId()
+  const gradientId = React.useId()
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      className={className}
+      role="img"
+      aria-labelledby={titleId}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title id={titleId}>Morpho Logo</title>
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#60a5fa" />
+          <stop offset="100%" stopColor="#2563eb" />
+        </linearGradient>
+      </defs>
+      <rect x="2" y="2" width="44" height="44" rx="12" fill={`url(#${gradientId})`} />
+      <path
+        d="M15 32V16.5c0-1.1.9-2 2-2h1.4c.8 0 1.5.4 1.9 1.1l4.6 8.1 4.6-8.1c.4-.7 1.1-1.1 1.9-1.1H32c1.1 0 2 .9 2 2V32h-3.8V21.7l-4.6 8.2c-.4.7-1.1 1.1-1.9 1.1h-.4c-.8 0-1.5-.4-1.9-1.1l-4.6-8.1V32H15Z"
+        fill="#0f172a"
+      />
+    </svg>
+  )
+}

--- a/_figma/src/components/pages/Portfolio.tsx
+++ b/_figma/src/components/pages/Portfolio.tsx
@@ -42,6 +42,7 @@ import { ConnectionStatusCard } from "../ConnectionStatusCard"
 import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Tooltip as RechartsTooltip, Area, AreaChart } from "recharts"
 import { Network } from "../NetworkSelector"
 import { USDCLogo, EthereumLogo, weETHLogo as WeETHLogo, SEAMLogo } from "../ui/crypto-logos"
+import { MorphoLogo } from "../icons/logos/MorphoLogo"
 
 interface PortfolioProps {
   currentNetwork: Network
@@ -235,7 +236,7 @@ export function Portfolio({ currentNetwork, isConnected, onConnectWallet, onView
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.2 }}
       >
-        <Card className="bg-slate-900/80 border-slate-700 hover:bg-slate-900/90 transition-all duration-300">
+        <Card className="text-card-foreground flex flex-col gap-6 rounded-xl border bg-blue-500/10 border-blue-400/30 hover:bg-blue-500/15 transition-all duration-300">
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
@@ -550,6 +551,44 @@ export function Portfolio({ currentNetwork, isConnected, onConnectWallet, onView
         </Card>
       </motion.div>
 
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.45 }}
+      >
+        <Card className="bg-slate-900/80 border-slate-700 hover:bg-slate-900/90 transition-all duration-300">
+          <CardContent className="p-6">
+            <div className="flex items-start space-x-4">
+              <div className="w-12 h-12 bg-blue-500/20 rounded-xl flex items-center justify-center">
+                <MorphoLogo className="h-6 w-6" size={24} />
+              </div>
+
+              <div className="flex-1 space-y-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-white mb-2">
+                    Where can I view/manage my Seamless Vaults?
+                  </h3>
+                  <p className="text-slate-300 leading-relaxed">
+                    Your Seamless Vault (powered by Morpho) positions are now managed directly in the Morpho App. This includes depositing, withdrawing, and claiming any rewards earned from the Seamless Vaults on Morpho.
+                  </p>
+                </div>
+
+                <div className="flex flex-col sm:flex-row gap-3">
+                  <Button
+                    className="bg-blue-600 hover:bg-blue-500 text-white flex items-center gap-2"
+                    onClick={() => window.open('https://app.morpho.org/base/dashboard', '_blank', 'noopener,noreferrer')}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    Open Morpho App
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+
+      
       {/* Position Management Section - Integrated from ManagePositions */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}

--- a/src/components/icons/logos/morpho-logo.tsx
+++ b/src/components/icons/logos/morpho-logo.tsx
@@ -1,0 +1,31 @@
+import type { SVGProps } from 'react'
+import { useId } from 'react'
+
+export function MorphoLogo({ className, ...props }: SVGProps<SVGSVGElement>) {
+  const titleId = useId()
+  const gradientId = useId()
+
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      <title id={titleId}>Morpho Logo</title>
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#60a5fa" />
+          <stop offset="100%" stopColor="#2563eb" />
+        </linearGradient>
+      </defs>
+      <rect x="2" y="2" width="44" height="44" rx="12" fill={`url(#${gradientId})`} />
+      <path
+        d="M15 32V16.5c0-1.1.9-2 2-2h1.4c.8 0 1.5.4 1.9 1.1l4.6 8.1 4.6-8.1c.4-.7 1.1-1.1 1.9-1.1H32c1.1 0 2 .9 2 2V32h-3.8V21.7l-4.6 8.2c-.4.7-1.1 1.1-1.9 1.1h-.4c-.8 0-1.5-.4-1.9-1.1l-4.6-8.1V32H15Z"
+        fill="#0f172a"
+      />
+    </svg>
+  )
+}

--- a/src/features/portfolio/components/morpho-vaults-info-card.tsx
+++ b/src/features/portfolio/components/morpho-vaults-info-card.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from 'lucide-react'
-import { useId } from 'react'
+import { MorphoLogo } from '@/components/icons/logos/morpho-logo'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 
@@ -8,16 +8,14 @@ interface MorphoVaultsInfoCardProps {
 }
 
 export function MorphoVaultsInfoCard({ className }: MorphoVaultsInfoCardProps) {
-  const gradientId = useId()
-
   return (
     <Card
-      className={`bg-slate-900/80 border border-blue-600/40 shadow-[0_0_45px_rgba(37,99,235,0.12)] transition-colors duration-300 ${className ?? ''}`}
+      className={`text-card-foreground flex flex-col gap-6 rounded-xl border bg-blue-500/10 border-blue-400/30 hover:bg-blue-500/15 transition-all duration-300 ${className ?? ''}`}
     >
       <CardContent className="p-6">
         <div className="flex items-start gap-4">
           <div className="w-12 h-12 rounded-xl bg-blue-500/20 flex items-center justify-center flex-shrink-0">
-            <MorphoGlyph className="h-6 w-6" gradientId={gradientId} />
+            <MorphoLogo className="h-6 w-6" />
             <span className="sr-only">Morpho</span>
           </div>
 
@@ -33,16 +31,12 @@ export function MorphoVaultsInfoCard({ className }: MorphoVaultsInfoCardProps) {
               </p>
             </div>
 
-            <div>
+            <div className="flex flex-col sm:flex-row gap-3">
               <Button
                 asChild
                 className="bg-blue-600 hover:bg-blue-500 text-white flex items-center gap-2"
               >
-                <a
-                  href="https://app.morpho.org/ethereum/dashboard"
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a href="https://app.morpho.org/base/dashboard" target="_blank" rel="noreferrer">
                   <ExternalLink className="h-4 w-4" />
                   Open Morpho App
                 </a>
@@ -52,29 +46,5 @@ export function MorphoVaultsInfoCard({ className }: MorphoVaultsInfoCardProps) {
         </div>
       </CardContent>
     </Card>
-  )
-}
-
-function MorphoGlyph({ className, gradientId }: { className?: string; gradientId: string }) {
-  return (
-    <svg
-      viewBox="0 0 48 48"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      focusable="false"
-      className={className}
-    >
-      <defs>
-        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#60a5fa" />
-          <stop offset="100%" stopColor="#2563eb" />
-        </linearGradient>
-      </defs>
-      <rect x="2" y="2" width="44" height="44" rx="12" fill={`url(#${gradientId})`} />
-      <path
-        d="M15 32V16.5c0-1.1.9-2 2-2h1.4c.8 0 1.5.4 1.9 1.1l4.6 8.1 4.6-8.1c.4-.7 1.1-1.1 1.9-1.1H32c1.1 0 2 .9 2 2V32h-3.8V21.7l-4.6 8.2c-.4.7-1.1 1.1-1.9 1.1h-.4c-.8 0-1.5-.4-1.9-1.1l-4.6-8.1V32H15Z"
-        fill="#0f172a"
-      />
-    </svg>
   )
 }

--- a/src/routes/portfolio.tsx
+++ b/src/routes/portfolio.tsx
@@ -339,14 +339,6 @@ function PortfolioPage() {
         />
       </motion.div>
 
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, delay: 0.15 }}
-      >
-        <MorphoVaultsInfoCard />
-      </motion.div>
-
       {/* Portfolio Chart */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -414,6 +406,14 @@ function PortfolioPage() {
           )}
         </motion.div>
       )}
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.35 }}
+      >
+        <MorphoVaultsInfoCard />
+      </motion.div>
 
       {/* Active Positions */}
       <motion.div


### PR DESCRIPTION
## Summary
- add a morphed vaults info card to the portfolio page with direct link to the Morpho dashboard
- sync the Figma portfolio reference with the new card layout
- introduce a reusable component for the card with inline Morpho glyph icon

## Testing
- bun check:fix

Fixes #195