### PR TITLE
feat: add staking nav link

### DIFF
--- a/src/components/VerticalNavbar.tsx
+++ b/src/components/VerticalNavbar.tsx
@@ -16,6 +16,7 @@ export interface NavigationItem {
   description: string
   subtitle?: string
   badge?: string
+  externalUrl?: string
 }
 
 interface SocialLink {
@@ -32,7 +33,7 @@ interface CommunitySection {
 
 interface NavbarProps {
   currentPage: string
-  onPageChange: (page: string) => void
+  onPageChange: (page: string, options?: { externalUrl?: string }) => void
   navigationItems: Array<NavigationItem>
   communitySection: CommunitySection
   platformTVL: React.ReactNode
@@ -91,13 +92,22 @@ function NavigationItem({
 }: {
   item: NavigationItem
   isActive: boolean
-  onClick: () => void
+  onClick: (options?: { externalUrl?: string }) => void
 }) {
   const Icon = item.icon
 
+  const handleClick = () => {
+    if (item.externalUrl) {
+      onClick({ externalUrl: item.externalUrl })
+      return
+    }
+
+    onClick()
+  }
+
   return (
     <motion.button
-      onClick={onClick}
+      onClick={handleClick}
       className={cn(
         'w-full group relative rounded-xl border transition-all duration-200 cursor-pointer',
         isActive
@@ -211,7 +221,7 @@ function NavbarContent({
   className,
 }: {
   currentPage: string
-  onPageChange: (pageId: string) => void
+  onPageChange: (pageId: string, options?: { externalUrl?: string }) => void
   navigationItems: Array<NavigationItem>
   communitySection: CommunitySection
   platformTVL: React.ReactNode
@@ -261,7 +271,7 @@ function NavbarContent({
               key={item.id}
               item={item}
               isActive={currentPage === item.id}
-              onClick={() => onPageChange(item.id)}
+              onClick={(options) => onPageChange(item.id, options)}
             />
           ))}
         </div>
@@ -343,8 +353,16 @@ export function VerticalNavbar({
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const mobileNavDescriptionId = useId()
 
-  const handlePageChange = (pageId: string) => {
-    onPageChange(pageId)
+  const handlePageChange = (pageId: string, options?: { externalUrl?: string }) => {
+    if (options?.externalUrl) {
+      if (typeof window !== 'undefined') {
+        window.open(options.externalUrl, '_blank', 'noopener,noreferrer')
+      }
+      setIsMobileMenuOpen(false)
+      return
+    }
+
+    onPageChange(pageId, options)
     setIsMobileMenuOpen(false) // Close mobile menu when page changes
   }
 

--- a/src/components/main-layout.tsx
+++ b/src/components/main-layout.tsx
@@ -60,6 +60,7 @@ const navigationItems = [
     description: 'Stake SEAM tokens',
     badge: 'New',
     subtitle: 'Stake SEAM tokens to earn protocol rewards',
+    externalUrl: 'https://legacy.seamlessprotocol.com/#/?tab=Staking',
   },
   features.governance && {
     id: 'governance',
@@ -153,7 +154,14 @@ export function MainLayout({ children }: MainLayoutProps) {
 
   const currentPage = getCurrentPage()
 
-  const handlePageChange = (pageId: string) => {
+  const handlePageChange = (pageId: string, options?: { externalUrl?: string }) => {
+    if (options?.externalUrl) {
+      if (typeof window !== 'undefined') {
+        window.open(options.externalUrl, '_blank', 'noopener,noreferrer')
+      }
+      return
+    }
+
     const route = routeMapping[pageId]
     if (route) {
       // biome-ignore lint/suspicious/noExplicitAny: route mapping is safe here

--- a/src/stories/components/vertical-navbar.stories.tsx
+++ b/src/stories/components/vertical-navbar.stories.tsx
@@ -46,6 +46,7 @@ const navigationItems = [
     icon: Coins,
     description: 'Stake SEAM tokens',
     badge: 'New',
+    externalUrl: 'https://legacy.seamlessprotocol.com/#/?tab=Staking',
   },
   {
     id: 'governance',
@@ -137,7 +138,13 @@ function NavbarWrapper({ currentPage }: { currentPage: string }) {
       <div className="hidden lg:block w-80 flex-shrink-0">
         <VerticalNavbar
           currentPage={page}
-          onPageChange={setPage}
+          onPageChange={(pageId, options) => {
+            if (options?.externalUrl) {
+              window.open(options.externalUrl, '_blank', 'noopener,noreferrer')
+              return
+            }
+            setPage(pageId)
+          }}
           navigationItems={navigationItems}
           communitySection={communitySection}
           platformTVL="$142.8M"
@@ -155,7 +162,13 @@ function NavbarWrapper({ currentPage }: { currentPage: string }) {
                 <div className="lg:hidden">
                   <VerticalNavbar
                     currentPage={page}
-                    onPageChange={setPage}
+                    onPageChange={(pageId, options) => {
+                      if (options?.externalUrl) {
+                        window.open(options.externalUrl, '_blank', 'noopener,noreferrer')
+                        return
+                      }
+                      setPage(pageId)
+                    }}
                     navigationItems={navigationItems}
                     communitySection={communitySection}
                     platformTVL="$142.8M"
@@ -209,7 +222,11 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     currentPage: 'portfolio',
-    onPageChange: () => {},
+    onPageChange: (_pageId: string, options?: { externalUrl?: string }) => {
+      if (options?.externalUrl) {
+        window.open(options.externalUrl, '_blank', 'noopener,noreferrer')
+      }
+    },
     navigationItems,
     communitySection,
     platformTVL: '$142.8M',


### PR DESCRIPTION
## Summary
- add optional url support to vertical navbar navigation items and propagate through menu handlers
- surface the staking nav badge as an external link to legacy staking until the new page is ready
- adjust storybook fixture and app layout to exercise the new external navigation behaviour

## Testing
- bun check:fix

Fixes #194