### PR TITLE
ci: use production environment for IPFS deploy

### DIFF
--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Purpose

- Ensure the IPFS deploy uses production-scoped secrets by targeting the "production" environment.

What changed

- .github/workflows/deploy-to-ipfs.yml: set `environment: production` on the deploy job. No app code changes.

Secrets expected (Environment: production)

- VITE_WALLETCONNECT_PROJECT_ID (prod)
- VITE_THEGRAPH_API_KEY (prod; Graph Gateway preferred)
- VITE_SENTRY_DSN (prod)
- VITE_GA4_MEASUREMENT_ID (prod)
- VITE_ALCHEMY_API_KEY (prod)
- PINATA_JWT
- Optional: VITE_COINGECKO_API_URL

Verification

- After merge, run "Deploy to IPFS" on main.
- On beta.seamlessprotocol.com, confirm:
  - No "[Sentry] No DSN..." or "[GA4] No Measurement ID..." logs.
  - WalletConnect requests include the prod `projectId`.
  - The Graph requests include `Authorization: Bearer <prod key>`.
  - RPC calls use Alchemy (`base-mainnet.g.alchemy.com/v2/<key>`) when key is set.

Notes

- Using environment-scoped secrets allows separate dev/prod values with the same names. CI/dev jobs continue using repo-level values unless they target an environment.
- Optional: set `VITE_SENTRY_ENVIRONMENT=production` and `VITE_SENTRY_RELEASE=${GITHUB_SHA}` for richer Sentry metadata.
- Optional: if you want Base subgraph behind the Graph Gateway (not Studio), set `VITE_LEVERAGE_TOKENS_SUBGRAPH_BASE` in the production environment.
