### PR TITLE
fix: avoid APY refetch on token detail by reusing table query (#294)

### DIFF
--- a/src/features/leverage-tokens/components/FeaturedLeverageToken.tsx
+++ b/src/features/leverage-tokens/components/FeaturedLeverageToken.tsx
@@ -58,8 +58,8 @@ export function FeaturedLeverageToken({
 
           {/* Stats Grid */}
           <div className="space-y-2">
-            {/* APY Row - only show if not zero */}
-            {apyData && apyData.totalAPY !== 0 && (
+            {/* APY Row - show skeleton while loading; hide after load if zero */}
+            {(isApyLoading || isApyError || (apyData && apyData.totalAPY !== 0)) && (
               <div className="flex justify-between items-center">
                 <span className="text-sm text-[var(--text-secondary)]">APY</span>
                 {isApyError ? (

--- a/src/routes/leverage-tokens.$chainId.$id.tsx
+++ b/src/routes/leverage-tokens.$chainId.$id.tsx
@@ -25,7 +25,10 @@ import { useLeverageTokenDetailedMetrics } from '@/features/leverage-tokens/hook
 import { useLeverageTokenPriceComparison } from '@/features/leverage-tokens/hooks/useLeverageTokenPriceComparison'
 import { useLeverageTokenState } from '@/features/leverage-tokens/hooks/useLeverageTokenState'
 import { useLeverageTokenUserPosition } from '@/features/leverage-tokens/hooks/useLeverageTokenUserPosition'
-import { getLeverageTokenConfig } from '@/features/leverage-tokens/leverageTokens.config'
+import {
+  getAllLeverageTokenConfigs,
+  getLeverageTokenConfig,
+} from '@/features/leverage-tokens/leverageTokens.config'
 import { generateLeverageTokenFAQ } from '@/features/leverage-tokens/utils/faqGenerator'
 import { useTokensAPY } from '@/features/portfolio/hooks/usePositionsAPY'
 import { useGA } from '@/lib/config/ga4.config'
@@ -126,14 +129,15 @@ export const Route = createFileRoute('/leverage-tokens/$chainId/$id')({
         : undefined
     // No collateral read in this route for now
 
-    // Pre-load APY data for the tooltip
+    // Pre-load APY data for all leverage tokens so navigation shares cache
+    const allLeverageConfigs = getAllLeverageTokenConfigs()
     const {
       data: tokensAPYData,
       isLoading: isApyLoading,
       isError: isApyError,
     } = useTokensAPY({
-      tokens: tokenConfig ? [tokenConfig] : [],
-      enabled: !!tokenConfig, // Only enable if we have a valid config
+      tokens: allLeverageConfigs,
+      enabled: allLeverageConfigs.length > 0,
     })
 
     // Get APY data for this specific token


### PR DESCRIPTION
Fixes #294

Summary
- Reuse the same TanStack Query for APY between the leverage tokens table and the token detail page, so navigation does not trigger a second fetch.
- Add APY skeleton to Featured cards while APY is loading.

Details
- Token detail route now calls useTokensAPY with the full leverage token config list (via getAllLeverageTokenConfigs), matching the table’s queryKey.
- useTokensAPY already has staleTime=5m and refetchOnMount=false, so cache is reused across SPA navigations.
- Featured cards render a skeleton for APY during loading and show N/A on error.

Validation
- Ran bun check:fix (Biome + typecheck): passed
- Built successfully with bun run build

Follow-ups
- Optional query persistence across hard reloads if desired (localStorage + TTL) or bumping staleTime if acceptable.
