### PR TITLE
chore: update default slippage to 3% and presets to 1%, 2%, 3%

### DIFF
--- a/src/features/leverage-tokens/constants.ts
+++ b/src/features/leverage-tokens/constants.ts
@@ -8,10 +8,10 @@ export const MIN_MINT_AMOUNT_DISPLAY = '0.01'
 export const MIN_REDEEM_AMOUNT_DISPLAY = '0.01'
 
 // Default slippage tolerance shown in the UI (percent as string)
-export const DEFAULT_SLIPPAGE_PERCENT_DISPLAY = '0.5'
+export const DEFAULT_SLIPPAGE_PERCENT_DISPLAY = '3.0'
 
 // Preset slippage options (percent strings) shown in the advanced UI
-export const SLIPPAGE_PRESETS_PERCENT_DISPLAY = ['0.1', '0.5', '1.0'] as const
+export const SLIPPAGE_PRESETS_PERCENT_DISPLAY = ['1.0', '2.0', '3.0'] as const
 
 // Preset percentage options for amount selection (25%, 50%, 75%, 100%)
 export const AMOUNT_PERCENTAGE_PRESETS = [25, 50, 75, 100] as const


### PR DESCRIPTION
- Increase default slippage from 0.5% to 3.0% for better transaction success rates
- Update slippage presets from [0.1%, 0.5%, 1.0%] to [1.0%, 2.0%, 3.0%]
- Affects both mint and redeem flows