### PR TITLE
fix: display correct output amounts in redeem PendingStep

### DIFF
--- a/src/features/leverage-tokens/components/leverage-token-redeem-modal/PendingStep.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-redeem-modal/PendingStep.tsx
@@ -11,7 +11,8 @@ interface LeverageTokenConfig {
 type PendingMode = 'awaitingWallet' | 'onChain'
 
 interface PendingStepProps {
-  amount: string
+  expectedCollateralAmount: string
+  collateralSymbol: string
   leverageTokenConfig: LeverageTokenConfig
   mode?: PendingMode
   transactionHash?: `0x${string}` | undefined
@@ -20,7 +21,8 @@ interface PendingStepProps {
 }
 
 export function PendingStep({
-  amount,
+  expectedCollateralAmount,
+  collateralSymbol,
   leverageTokenConfig,
   mode = 'awaitingWallet',
   transactionHash,
@@ -50,9 +52,9 @@ export function PendingStep({
       <Card variant="gradient" className="border border-border bg-card p-4">
         <div className="space-y-2 text-sm">
           <div className="flex justify-between">
-            <span className="text-secondary-foreground">Redeeming</span>
+            <span className="text-secondary-foreground">Receiving</span>
             <span className="text-foreground">
-              {amount} {leverageTokenConfig.symbol}
+              {expectedCollateralAmount} {collateralSymbol}
               {expectedDebtAmount && expectedDebtAmount !== '0' && debtAssetSymbol && (
                 <>
                   {' '}

--- a/src/features/leverage-tokens/components/leverage-token-redeem-modal/index.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-redeem-modal/index.tsx
@@ -789,7 +789,8 @@ export function LeverageTokenRedeemModal({
       case 'pending':
         return (
           <PendingStep
-            amount={form.amount}
+            expectedCollateralAmount={expectedAmount}
+            collateralSymbol={selectedOutputAsset.symbol}
             leverageTokenConfig={{
               symbol: leverageTokenConfig.symbol,
               name: leverageTokenConfig.name,


### PR DESCRIPTION
Update PendingStep to show collateral and debt outputs (matching MetaMask) instead of leverage token inputs. Changes "Redeeming" label to "Receiving" for semantic clarity.

Before: "Redeeming 0.542936 RLP-USDC-6.75x + 0.019686 USDC"
After:  "Receiving 0.523 RLP + 0.0197 USDC"