### PR TITLE
feat: custom lifi api key

### DIFF
--- a/.github/workflows/deploy-to-ipfs.yml
+++ b/.github/workflows/deploy-to-ipfs.yml
@@ -53,6 +53,7 @@ jobs:
         VITE_DISABLE_AVAILABLE_REWARDS: ${{ vars.VITE_DISABLE_AVAILABLE_REWARDS }}
         VITE_DISABLE_SEAM_STAKING: ${{ vars.VITE_DISABLE_SEAM_STAKING }}
         VITE_LIFI_INTEGRATOR: seamless
+        VITE_LIFI_API_KEY: ${{ vars.VITE_LIFI_API_KEY }}
 
     - name: Install action dependencies
       run: |

--- a/src/domain/shared/adapters/lifi.ts
+++ b/src/domain/shared/adapters/lifi.ts
@@ -70,7 +70,7 @@ export function createLifiQuoteAdapter(opts: LifiAdapterOptions): QuoteFn {
     fromAddress,
     slippageBps = DEFAULT_SLIPPAGE_BPS,
     // Always use li.quest as documented by LiFi for /v1/quote
-    baseUrl = opts.baseUrl ?? 'https://li.quest',
+    baseUrl = opts.baseUrl ?? 'https://partner-seashell.li.quest',
     // Read from Vite env in browser; avoid referencing process.env in client bundles
     apiKey = opts.apiKey ?? readEnv('VITE_LIFI_API_KEY') ?? readEnv('LIFI_API_KEY'),
     order = 'CHEAPEST',


### PR DESCRIPTION
LiFi has created a special API key for us that can be used in the front end. This should resolve any rate limit issues. This key is still rate limited but in a more custom way

I've added this key to the IPFS build pipeline as well