### PR TITLE
fix: ensure consistent APY breakdown data across components

### DIFF
--- a/src/components/APYBreakdownTooltip.tsx
+++ b/src/components/APYBreakdownTooltip.tsx
@@ -1,13 +1,10 @@
-import type { LeverageToken } from '@/features/leverage-tokens/components/leverage-token-table'
-import { useLeverageTokenAPY } from '@/features/leverage-tokens/hooks/useLeverageTokenAPY'
 import type { APYBreakdownData } from './APYBreakdown'
 import { APYBreakdown } from './APYBreakdown'
 import { Skeleton } from './ui/skeleton'
 import { cn } from './ui/utils'
 
 interface APYBreakdownTooltipProps {
-  token: LeverageToken
-  apyData?: APYBreakdownData
+  apyData?: APYBreakdownData | undefined
   isLoading?: boolean
   isError?: boolean
   compact?: boolean
@@ -15,33 +12,17 @@ interface APYBreakdownTooltipProps {
 }
 
 /**
- * APY Breakdown tooltip that uses the hook to fetch real yield data
+ * APY Breakdown tooltip - purely presentational component that displays APY data.
+ * All data fetching should be done by parent components to ensure consistency.
  */
 export function APYBreakdownTooltip({
-  token,
   apyData,
-  isLoading: preloadedIsLoading = false,
-  isError: preloadedIsError = false,
+  isLoading = false,
+  isError = false,
   compact = false,
   className,
 }: APYBreakdownTooltipProps) {
-  // Use preloaded data if provided, otherwise fetch on demand
-  const {
-    data: onDemandApyData,
-    isLoading: onDemandIsLoading,
-    isError: onDemandIsError,
-  } = useLeverageTokenAPY({
-    tokenAddress: token.address,
-    leverageToken: token,
-    enabled: !apyData, // Only fetch if no preloaded data provided
-  })
-
-  // Use preloaded data if provided, otherwise use on-demand data
-  const finalApyData = apyData || onDemandApyData
-  const finalIsLoading = apyData ? false : preloadedIsLoading || onDemandIsLoading
-  const finalIsError = apyData ? false : preloadedIsError || onDemandIsError
-
-  if (finalIsLoading) {
+  if (isLoading) {
     return (
       <div className="min-w-[240px] space-y-3 rounded-lg border border-border bg-card p-4">
         <div className="text-sm font-semibold text-foreground">APY Breakdown</div>
@@ -54,7 +35,7 @@ export function APYBreakdownTooltip({
     )
   }
 
-  if (finalIsError || !finalApyData) {
+  if (isError || !apyData) {
     return (
       <div className="min-w-[240px] space-y-2 rounded-lg border border-border bg-card p-4">
         <div className="text-sm font-semibold text-foreground">APY Breakdown</div>
@@ -65,7 +46,7 @@ export function APYBreakdownTooltip({
 
   return (
     <APYBreakdown
-      data={finalApyData}
+      data={apyData}
       compact={compact}
       className={cn('min-w-[240px] rounded-lg border border-border bg-card', className)}
     />

--- a/src/components/ApyInfoTooltip.tsx
+++ b/src/components/ApyInfoTooltip.tsx
@@ -3,12 +3,10 @@ import { useState } from 'react'
 import type { APYBreakdownData } from '@/components/APYBreakdown'
 import { APYBreakdownTooltip } from '@/components/APYBreakdownTooltip'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { LeverageToken } from '@/features/leverage-tokens/components/leverage-token-table'
 
 type IconSize = 'sm' | 'md' | 'lg'
 
 interface ApyInfoTooltipProps {
-  token: LeverageToken
   apyData?: APYBreakdownData | undefined
   isLoading?: boolean
   isError?: boolean
@@ -22,7 +20,6 @@ interface ApyInfoTooltipProps {
 }
 
 export function ApyInfoTooltip({
-  token,
   apyData,
   isLoading = false,
   isError = false,
@@ -72,13 +69,7 @@ export function ApyInfoTooltip({
         align={align}
         sideOffset={sideOffset}
       >
-        <APYBreakdownTooltip
-          token={token}
-          compact
-          {...(apyData && { apyData })}
-          isLoading={isLoading}
-          isError={isError}
-        />
+        <APYBreakdownTooltip compact apyData={apyData} isLoading={isLoading} isError={isError} />
       </TooltipContent>
     </Tooltip>
   )

--- a/src/features/leverage-tokens/components/leverage-token-table/LeverageTokenMobileCard.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-table/LeverageTokenMobileCard.tsx
@@ -83,8 +83,7 @@ export function LeverageTokenMobileCard({
                   </span>
                 )}
                 <ApyInfoTooltip
-                  token={token}
-                  {...(apyData && { apyData })}
+                  apyData={apyData}
                   isLoading={isApyLoading ?? false}
                   isError={isApyError ?? false}
                   iconSize="md"

--- a/src/features/leverage-tokens/components/leverage-token-table/LeverageTokenTable.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-table/LeverageTokenTable.tsx
@@ -475,8 +475,7 @@ export function LeverageTokenTable({
                             </span>
                           )}
                           <ApyInfoTooltip
-                            token={token}
-                            {...(tokenApyData && { apyData: tokenApyData })}
+                            apyData={tokenApyData}
                             isLoading={apyLoading}
                             isError={tokenApyError}
                             iconSize="md"

--- a/src/features/portfolio/components/active-positions.tsx
+++ b/src/features/portfolio/components/active-positions.tsx
@@ -85,7 +85,7 @@ function PositionAPYDisplay({ position, isLoading }: { position: Position; isLoa
               position.leverageTokenAddress as `0x${string}`,
             )
             return tokenConfig ? (
-              <APYBreakdownTooltip token={tokenConfig} apyData={apyBreakdown} />
+              <APYBreakdownTooltip apyData={apyBreakdown} />
             ) : (
               <p>Annual Percentage Yield</p>
             )

--- a/src/routes/leverage-tokens.$chainId.$id.tsx
+++ b/src/routes/leverage-tokens.$chainId.$id.tsx
@@ -395,8 +395,7 @@ export const Route = createFileRoute('/leverage-tokens/$chainId/$id')({
                     </TooltipTrigger>
                     <TooltipContent className="p-0 text-sm border border-border bg-card">
                       <APYBreakdownTooltip
-                        token={tokenConfig}
-                        {...(apyData && { apyData })}
+                        apyData={apyData}
                         isLoading={isApyLoading ?? false}
                         isError={isApyError ?? false}
                         compact
@@ -483,8 +482,7 @@ export const Route = createFileRoute('/leverage-tokens/$chainId/$id')({
                     </TooltipTrigger>
                     <TooltipContent className="p-0 text-sm bg-[color-mix(in_srgb,var(--surface-card) 92%,transparent)] border border-[var(--divider-line)]">
                       <APYBreakdownTooltip
-                        token={tokenConfig}
-                        {...(apyData && { apyData })}
+                        apyData={apyData}
                         isLoading={isApyLoading ?? false}
                         isError={isApyError ?? false}
                         compact


### PR DESCRIPTION
Fixes #436

Make `APYBreakdownTooltip` purely presentational by removing independent data fetching. This ensures APY data is always sourced from parent components, preventing inconsistencies between featured section and tooltip displays.

**Changes:**
- Remove `useLeverageTokenAPY` hook from `APYBreakdownTooltip`
- Remove `token` parameter from `APYBreakdownTooltip` and `ApyInfoTooltip`
- Remove conditional spread operators that prevented undefined data from being passed
- Clean up unnecessary intermediate variables