### PR TITLE
chore: exclude open ocean quotes

### DIFF
--- a/src/domain/shared/adapters/balmy.ts
+++ b/src/domain/shared/adapters/balmy.ts
@@ -32,6 +32,7 @@ export function createBalmyQuoteAdapter(opts: BalmyAdapterOptions): QuoteFn {
       'fly-trade',
       'swing',
       'xy-finance',
+      'open-ocean',
       ...(opts.excludeAdditionalSources ?? []),
     ]
 

--- a/tests/unit/domain/shared/adapters/balmy.spec.ts
+++ b/tests/unit/domain/shared/adapters/balmy.spec.ts
@@ -76,7 +76,9 @@ describe('createBalmyQuoteAdapter', () => {
         slippagePercentage: 0.5,
         takerAddress: CALLER,
         recipient: ROUTER,
-        filters: { excludeSources: ['sushiswap', 'fly-trade', 'swing', 'xy-finance'] },
+        filters: {
+          excludeSources: ['sushiswap', 'fly-trade', 'swing', 'xy-finance', 'open-ocean'],
+        },
         sourceConfig: { global: { disableValidation: true } },
       }),
       config: {
@@ -255,7 +257,14 @@ describe('createBalmyQuoteAdapter', () => {
         takerAddress: CALLER,
         recipient: ROUTER,
         filters: {
-          excludeSources: ['sushiswap', 'fly-trade', 'swing', 'xy-finance', 'test-source'],
+          excludeSources: [
+            'sushiswap',
+            'fly-trade',
+            'swing',
+            'xy-finance',
+            'open-ocean',
+            'test-source',
+          ],
         },
         sourceConfig: { global: { disableValidation: true } },
       }),


### PR DESCRIPTION
currently returning some insane quotes e.g. https://open-api.openocean.finance/v3/eth/swap_quote?inTokenAddress=0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0&outTokenAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&amount=0.000797735494244914&slippage=0.01&gasPrice=0.147742945&account=0xb0764dE7eeF0aC69855C431334B7BC51A96E6DbA&referrer=0x0000000000000000000000000000000000000000 returns https://gist.github.com/chad-js/7c77bd148aebb5ecac874c799013fe2f