### PR TITLE
feat: add reset button to advanced controls and remove preset buttons

### DIFF
--- a/src/features/leverage-tokens/components/SlippageInput.tsx
+++ b/src/features/leverage-tokens/components/SlippageInput.tsx
@@ -4,12 +4,11 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils/cn'
 
 interface SlippageInputProps {
   label: string
   tooltipText?: string
-  presets: ReadonlyArray<string>
+  defaultValue: string
   value: string
   onChange: (value: string) => void
   inputRef?: Ref<HTMLInputElement>
@@ -23,7 +22,7 @@ interface SlippageInputProps {
 export function SlippageInput({
   label,
   tooltipText,
-  presets,
+  defaultValue,
   value,
   onChange,
   inputRef,
@@ -34,6 +33,7 @@ export function SlippageInput({
   placeholder = '0.5',
 }: SlippageInputProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false)
+  const isResetDisabled = value === defaultValue
 
   const handleStepChange = (direction: 'up' | 'down') => {
     const currentValue = parseFloat(value) || 0
@@ -73,22 +73,6 @@ export function SlippageInput({
           )}
         </div>
         <div className="flex items-center space-x-2">
-          {presets.map((preset) => (
-            <Button
-              key={preset}
-              variant={value === preset ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => onChange(preset)}
-              className={cn(
-                'h-8 px-3 text-xs transition-colors',
-                value === preset
-                  ? 'border border-brand-purple bg-brand-purple text-primary-foreground hover:opacity-90'
-                  : 'border border-divider-line text-secondary-foreground hover:bg-[color-mix(in_srgb,var(--surface-elevated) 35%,transparent)] hover:text-foreground',
-              )}
-            >
-              {preset}%
-            </Button>
-          ))}
           <div className="flex items-center space-x-1">
             <div className="relative">
               <Input
@@ -118,6 +102,15 @@ export function SlippageInput({
             </div>
             <Percent className="h-3 w-3 text-muted-foreground" />
           </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onChange(defaultValue)}
+            disabled={isResetDisabled}
+            className="h-8 border border-divider-line px-3 text-xs text-secondary-foreground transition-colors hover:bg-[color-mix(in_srgb,var(--surface-elevated) 35%,transparent)] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-secondary-foreground"
+          >
+            Reset
+          </Button>
         </div>
       </div>
     </Card>

--- a/src/features/leverage-tokens/components/leverage-token-mint-modal/InputStep.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-mint-modal/InputStep.tsx
@@ -11,10 +11,10 @@ import { Separator } from '../../../../components/ui/separator'
 import { Skeleton } from '../../../../components/ui/skeleton'
 import {
   AMOUNT_PERCENTAGE_PRESETS,
-  FLASH_LOAN_ADJUSTMENT_PRESETS_PERCENT_DISPLAY,
+  DEFAULT_FLASH_LOAN_ADJUSTMENT_PERCENT_DISPLAY,
+  DEFAULT_SLIPPAGE_PERCENT_DISPLAY,
+  DEFAULT_SWAP_SLIPPAGE_PERCENT_DISPLAY,
   MIN_MINT_AMOUNT_DISPLAY,
-  SHARE_SLIPPAGE_PRESETS_PERCENT_DISPLAY_MINT,
-  SWAP_SLIPPAGE_PRESETS_PERCENT_DISPLAY,
 } from '../../constants'
 import { SlippageInput } from '../SlippageInput'
 
@@ -174,13 +174,6 @@ export function InputStep({
     return { label: `Mint ${leverageTokenConfig.symbol}`, busy: false }
   })()
 
-  const shareSlippagePresets =
-    leverageTokenConfig.slippagePresets?.mint?.presetsShareSlippage ??
-    SHARE_SLIPPAGE_PRESETS_PERCENT_DISPLAY_MINT
-  const flashLoanAdjustmentPresets =
-    leverageTokenConfig.slippagePresets?.mint?.presetsFlashLoanAdjustment ??
-    FLASH_LOAN_ADJUSTMENT_PRESETS_PERCENT_DISPLAY
-
   return (
     <div className="space-y-6">
       <div className="space-y-4">
@@ -272,7 +265,10 @@ export function InputStep({
             <SlippageInput
               label="Leverage Token Slippage Tolerance"
               tooltipText="The maximum allowed difference between previewed Leverage Tokens received and actual Leverage Tokens received when executed onchain."
-              presets={shareSlippagePresets}
+              defaultValue={
+                leverageTokenConfig.slippagePresets?.mint?.defaultShareSlippage ??
+                DEFAULT_SLIPPAGE_PERCENT_DISPLAY
+              }
               value={shareSlippage}
               onChange={onShareSlippageChange}
               inputRef={shareSlippageInputRef}
@@ -284,7 +280,7 @@ export function InputStep({
             <SlippageInput
               label="Swap Slippage Tolerance"
               tooltipText="Advanced setting. The default value works in most cases."
-              presets={SWAP_SLIPPAGE_PRESETS_PERCENT_DISPLAY}
+              defaultValue={DEFAULT_SWAP_SLIPPAGE_PERCENT_DISPLAY}
               value={swapSlippage}
               onChange={onSwapSlippageChange}
               step={0.01}
@@ -295,7 +291,10 @@ export function InputStep({
             <SlippageInput
               label="Flash Loan Adjustment"
               tooltipText="Advanced setting. The default value works in most cases."
-              presets={flashLoanAdjustmentPresets}
+              defaultValue={
+                leverageTokenConfig.slippagePresets?.mint?.defaultFlashLoanAdjustment ??
+                DEFAULT_FLASH_LOAN_ADJUSTMENT_PERCENT_DISPLAY
+              }
               value={flashLoanAdjustment}
               onChange={onFlashLoanAdjustmentChange}
               step={0.1}

--- a/src/features/leverage-tokens/components/leverage-token-redeem-modal/InputStep.tsx
+++ b/src/features/leverage-tokens/components/leverage-token-redeem-modal/InputStep.tsx
@@ -10,10 +10,10 @@ import { Separator } from '../../../../components/ui/separator'
 import { Skeleton } from '../../../../components/ui/skeleton'
 import {
   AMOUNT_PERCENTAGE_PRESETS,
-  COLLATERAL_SLIPPAGE_PRESETS_PERCENT_DISPLAY_REDEEM,
-  COLLATERAL_SWAP_ADJUSTMENT_PRESETS_PERCENT_DISPLAY,
+  DEFAULT_COLLATERAL_SLIPPAGE_PERCENT_DISPLAY,
+  DEFAULT_COLLATERAL_SWAP_ADJUSTMENT_PERCENT_DISPLAY,
+  DEFAULT_SWAP_SLIPPAGE_PERCENT_DISPLAY,
   MIN_REDEEM_AMOUNT_DISPLAY,
-  SWAP_SLIPPAGE_PRESETS_PERCENT_DISPLAY,
 } from '../../constants'
 import type { SwapConfig } from '../../leverageTokens.config'
 
@@ -168,10 +168,6 @@ export function InputStep({
     return { label: `Redeem ${leverageTokenConfig.symbol}`, busy: false }
   })()
 
-  const collateralSlippagePresets =
-    leverageTokenConfig.slippagePresets?.redeem?.presetsCollateralSlippage ??
-    COLLATERAL_SLIPPAGE_PRESETS_PERCENT_DISPLAY_REDEEM
-
   return (
     <div className="space-y-6">
       <div className="space-y-4">
@@ -254,7 +250,10 @@ export function InputStep({
             <SlippageInput
               label={`${leverageTokenConfig.collateralAsset.symbol} Slippage Tolerance`}
               tooltipText={`The maximum allowed difference between the previewed ${leverageTokenConfig.collateralAsset.symbol} amount received and actual amount received when executed onchain.`}
-              presets={collateralSlippagePresets}
+              defaultValue={
+                leverageTokenConfig.slippagePresets?.redeem?.defaultCollateralSlippage ??
+                DEFAULT_COLLATERAL_SLIPPAGE_PERCENT_DISPLAY
+              }
               value={collateralSlippage}
               onChange={onCollateralSlippageChange}
               inputRef={collateralSlippageInputRef}
@@ -266,7 +265,7 @@ export function InputStep({
             <SlippageInput
               label={`Collateral Swap Adjustment`}
               tooltipText="Advanced setting. The default value works in most cases."
-              presets={COLLATERAL_SWAP_ADJUSTMENT_PRESETS_PERCENT_DISPLAY}
+              defaultValue={DEFAULT_COLLATERAL_SWAP_ADJUSTMENT_PERCENT_DISPLAY}
               value={collateralSwapAdjustment}
               onChange={onCollateralSwapAdjustmentChange}
               step={0.01}
@@ -277,7 +276,7 @@ export function InputStep({
             <SlippageInput
               label="Swap Slippage Tolerance"
               tooltipText="Advanced setting. The default value works in most cases."
-              presets={SWAP_SLIPPAGE_PRESETS_PERCENT_DISPLAY}
+              defaultValue={DEFAULT_SWAP_SLIPPAGE_PERCENT_DISPLAY}
               value={swapSlippage}
               onChange={onSwapSlippageChange}
               step={0.01}

--- a/src/features/leverage-tokens/leverageTokens.config.ts
+++ b/src/features/leverage-tokens/leverageTokens.config.ts
@@ -126,12 +126,9 @@ export interface LeverageTokenConfig {
     mint?: {
       defaultShareSlippage?: string
       defaultFlashLoanAdjustment?: string
-      presetsShareSlippage?: Array<string>
-      presetsFlashLoanAdjustment?: Array<string>
     }
     redeem?: {
       defaultCollateralSlippage?: string
-      presetsCollateralSlippage?: Array<string>
     }
   }
 
@@ -819,9 +816,7 @@ export const leverageTokenConfigs: Record<string, LeverageTokenConfig> = {
     slippagePresets: {
       mint: {
         defaultShareSlippage: '1.7',
-        presetsShareSlippage: ['1.0', '1.5', '2.0'],
         defaultFlashLoanAdjustment: '1.7',
-        presetsFlashLoanAdjustment: ['1.0', '1.5', '2.0'],
       },
     },
     test: {


### PR DESCRIPTION
Removed presets and added "Reset" button to advanced controls

When default is already selected, button is disabled:
<img width="574" height="335" alt="Screenshot 2026-02-13 at 3 35 54 PM" src="https://github.com/user-attachments/assets/797f9e7a-a89f-4609-ac04-1ad5cfb2f54d" />

When not selected:
<img width="572" height="296" alt="Screenshot 2026-02-13 at 3 35 58 PM" src="https://github.com/user-attachments/assets/b6263fd4-45bd-461b-8764-987c2278f449" />